### PR TITLE
Fix GraphQL Owner User ID naming mismatch issue

### DIFF
--- a/app/api/gql/schema.graphqls
+++ b/app/api/gql/schema.graphqls
@@ -21,7 +21,7 @@ input TaskInput {
 	goal: String
 	dueAt: Time
 	context: String
-	ownerUserID: ID
+	ownerUserId: ID
 	workScopeIndex: Int
 	dependsOnTaskIds: [ID!]
 	numOfUnknowns: Int


### PR DESCRIPTION
@magicoder10 I found an issue of owner user id naming in GraphQL schema. It seems that frontend is posting lower case "Id", but in backend, it's looking for uppercase "ID".