### PR TITLE
server stored operations

### DIFF
--- a/app/api/gql/operations/operation.go
+++ b/app/api/gql/operations/operation.go
@@ -1,0 +1,10 @@
+package operations
+
+import _ "embed"
+
+//go:embed operations.gql
+var operations string
+
+func Operations() string {
+	return operations
+}

--- a/app/api/gql/server.go
+++ b/app/api/gql/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/teamyapp/one/identity"
+	"github.com/teamyapp/teamy-backend/app/api/gql/operations"
 	"github.com/teamyapp/teamy-backend/app/api/gql/resolver"
 )
 
@@ -74,6 +75,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	// handle server stored queries
+	if params.Query == "" {
+		params.Query = operations.Operations()
 	}
 
 	log.Println("begin GraphQL")

--- a/app/api/gql/server.go
+++ b/app/api/gql/server.go
@@ -78,6 +78,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// handle server stored queries
+    // Execute custom queries if specified
 	if params.Query == "" {
 		params.Query = operations.Operations()
 	}


### PR DESCRIPTION
Feature: If the frontend omit query string, will run `operations.gql`

1. No frontend changes.
2. The frontend need to refer to backend during development and changes this `operations.gql`

Good enough for now.