### PR TITLE
Remove active team check on task update

### DIFF
--- a/app/api/gql/resolver/task_input.go
+++ b/app/api/gql/resolver/task_input.go
@@ -12,3 +12,11 @@ type TaskInput struct {
 	OwnerUserID *graphql.ID
 	Status      *entity.TaskStatusEnum
 }
+
+type TaskCreationInput struct {
+	Goal        *string
+	DueAt       *graphql.Time
+	Context     *string
+	OwnerUserID *graphql.ID
+	Status      *entity.TaskStatusEnum
+}

--- a/app/api/gql/resolver/task_input.go
+++ b/app/api/gql/resolver/task_input.go
@@ -12,11 +12,3 @@ type TaskInput struct {
 	OwnerUserID *graphql.ID
 	Status      *entity.TaskStatusEnum
 }
-
-type TaskCreationInput struct {
-	Goal        *string
-	DueAt       *graphql.Time
-	Context     *string
-	OwnerUserID *graphql.ID
-	Status      *entity.TaskStatusEnum
-}

--- a/app/api/gql/resolver/task_mutation.go
+++ b/app/api/gql/resolver/task_mutation.go
@@ -38,12 +38,37 @@ type TaskUpdate struct {
 	task entity.Task
 }
 
-func (tu TaskUpdate) OwnedByTeam(args struct{ ID graphql.ID }) (TaskUpdate, error) {
-	id, err := fromGraphQLID(args.ID)
+func (tu TaskUpdate) OwnedByTeam(ctx context.Context, args struct{ ID graphql.ID }) (TaskUpdate, error) {
+	teamID, err := fromGraphQLID(args.ID)
 	if err != nil {
 		return tu, err
 	}
-	tu.task.OwnedByTeam = id
+	userID, err := identity.FromContext(ctx)
+	if err != nil {
+		return TaskUpdate{}, err
+	}
+	// check if the user is a member of the team
+	teams := tu.deps.Data.FilterTeams(func(t entity.Team) bool {
+		return t.ID == teamID
+	})
+	if len(teams) == 0 {
+		return tu, errors.Errorf("team %v does not exist", teamID)
+	}
+	if !teams[0].MemberIDs.Has(userID) {
+		return tu, errors.Errorf("user %v is not a member of team %v", userID, teamID)
+	}
+
+	// add the task to the team's task list if not there yet
+	_, err = tu.deps.Data.UpdateTeam(teamID, func(t entity.Team) entity.Team {
+		t.Tasks = t.Tasks.Add(tu.task.ID)
+		return t
+	})
+	if err != nil {
+		return tu, err
+	}
+
+	// make this team own this task (all team members has UPDATE privilige to the task)
+	tu.task.OwnedByTeam = teamID
 	newTask, err := tu.deps.Data.UpdateTask(tu.task)
 	if err != nil {
 		return tu, err

--- a/app/api/gql/resolver/task_mutation.go
+++ b/app/api/gql/resolver/task_mutation.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/graph-gophers/graphql-go"
@@ -13,55 +12,48 @@ import (
 
 func (m Mutation) CreateTask(
 	ctx context.Context,
-	args struct {
-		Task TaskInput
-	},
-) (Task, error) {
+	args struct{ Task TaskInput },
+) (TaskUpdate, error) {
 	userID, err := identity.FromContext(ctx)
 	if err != nil {
-		log.Println(err)
-		return Task{}, err
-	}
-	// find user
-	user, err := m.deps.Data.GetUser(userID)
-	if err != nil {
-		log.Println(err)
-		return Task{}, err
+		return TaskUpdate{}, err
 	}
 
 	task, err := fromGraphQLTaskInput(args.Task)
 	if err != nil {
-		log.Println(err)
-		return Task{}, err
-	}
-
-	activeTeams := m.deps.Data.FilterTeams(func(t entity.Team) bool {
-		return t.ID == user.ActiveTeamID
-	})
-	if err != nil {
-		log.Println(err)
-		return Task{}, err
-	}
-	if len(activeTeams) == 0 {
-		return Task{}, fmt.Errorf("user %v does not have an active team", userID)
+		return TaskUpdate{}, err
 	}
 
 	task.Status = entity.UPCOMING
 	task.OwnerUserId = &userID
-	task.OwnedByTeam = activeTeams[0].ID
 	task, err = m.deps.Data.CreateTask(toGraphQLID(userID), task)
 	if err != nil {
-		return Task{}, err
+		return TaskUpdate{}, err
 	}
-	// add task to team
-	_, err = m.deps.Data.UpdateTeam(activeTeams[0].ID, func(t entity.Team) entity.Team {
-		t.Tasks = append(t.Tasks, task.ID)
-		return t
-	})
+	return TaskUpdate{m.deps, task}, err
+}
+
+type TaskUpdate struct {
+	deps *Dependencies
+	task entity.Task
+}
+
+func (tu TaskUpdate) OwnedByTeam(args struct{ ID graphql.ID }) (TaskUpdate, error) {
+	id, err := fromGraphQLID(args.ID)
 	if err != nil {
-		return Task{}, err
+		return tu, err
 	}
-	return newTask(m.deps, task), err
+	tu.task.OwnedByTeam = id
+	newTask, err := tu.deps.Data.UpdateTask(tu.task)
+	if err != nil {
+		return tu, err
+	}
+	tu.task = newTask
+	return tu, nil
+}
+
+func (tu TaskUpdate) Task() Task {
+	return newTask(tu.deps, tu.task)
 }
 
 func (m Mutation) DeleteTask(ctx context.Context, args struct {

--- a/app/api/gql/schema.graphqls
+++ b/app/api/gql/schema.graphqls
@@ -174,7 +174,8 @@ Mutation
 type Mutation {
 	#########
 	# Tasks #
-	createTask(task: TaskInput!): Task!
+	"A task can exist independently from a team"
+	createTask(task: TaskCreationInput!): TaskUpdate!
 	updateTask(taskId: ID!, task: TaskInput!): Task!
 	deleteTask(taskId: ID!): Task!
 
@@ -200,6 +201,19 @@ type Mutation {
 
 	promoteTaskToNeedAttention(taskId: ID!): Team!	@deprecated(reason: "use TeamUpdate")
 	updateActiveTeam(teamId: ID!): User!			@deprecated(reason: "use UserUpdate")
+}
+
+input TaskCreationInput {
+	goal: String
+	context: String
+	dueAt: Time
+	ownerUserId: ID
+	status: TaskStatus
+}
+
+type TaskUpdate {
+	ownedByTeam(id: ID!): TaskUpdate!
+	task: Task!
 }
 
 input UserUpdateInput {

--- a/app/api/gql/schema.graphqls
+++ b/app/api/gql/schema.graphqls
@@ -212,6 +212,7 @@ input TaskCreationInput {
 }
 
 type TaskUpdate {
+	"change ownedByTeam of task field to id"
 	ownedByTeam(id: ID!): TaskUpdate!
 	task: Task!
 }

--- a/app/api/gql/server.go
+++ b/app/api/gql/server.go
@@ -98,7 +98,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	log.Info(ctx, "begin GraphQL")
+	log.Info(ctx, "begin GraphQL", params.Query)
 	response := h.Schema.Exec(ctx, params.Query, params.OperationName, params.Variables)
 	if response.Extensions == nil {
 		response.Extensions = make(map[string]interface{})


### PR DESCRIPTION
https://github.com/teamyapp/teamy-web/pull/140
Breaking Change: frontend needs to change accordingly. The new query is
```graphql
    mutation createTask($taskInput: TaskInput!) {
        createTask(task: $taskInput) {
            ownedByTeam(id: $teamId) {
                task {
                    id
                    goal
                    context
                    owner {
                        id
                    }
                }
            }
        }
    }
```