### PR TITLE
Remove task from team

### DIFF
--- a/app/api/gql/resolver/team_mutation.go
+++ b/app/api/gql/resolver/team_mutation.go
@@ -138,6 +138,22 @@ func (tu TeamUpdate) RemoveMember(args struct{ ID graphql.ID }) (TeamUpdate, err
 	return tu, nil
 }
 
+func (tu TeamUpdate) RemoveTask(args struct{ ID graphql.ID }) (TeamUpdate, error) {
+	taskID, err := fromGraphQLID(args.ID)
+	if err != nil {
+		return TeamUpdate{}, err
+	}
+	newTeam, err := tu.deps.Data.UpdateTeam(tu.team.ID, func(t entity.Team) entity.Team {
+		t.Tasks = t.Tasks.Remove(taskID)
+		return t
+	})
+	if err != nil {
+		return TeamUpdate{}, err
+	}
+	tu.team = newTeam
+	return tu, nil
+}
+
 func (tu TeamUpdate) PromoteTaskToNeedAttention(
 	ctx context.Context,
 	args struct {

--- a/app/api/gql/resolver/user.go
+++ b/app/api/gql/resolver/user.go
@@ -52,6 +52,7 @@ func (u User) Teams(ctx context.Context, args struct {
 	var idsMap map[oneEntity.ID]bool
 	var err error
 
+	// use OrderredSet instead of toIDsMap
 	if args.IDs != nil {
 		idsMap, err = toIDsMap(*args.IDs)
 		if err != nil {

--- a/app/api/gql/resolver/user.go
+++ b/app/api/gql/resolver/user.go
@@ -52,7 +52,7 @@ func (u User) Teams(ctx context.Context, args struct {
 	var idsMap map[oneEntity.ID]bool
 	var err error
 
-	// use OrderredSet instead of toIDsMap
+	// todo: use OrderredSet instead of toIDsMap
 	if args.IDs != nil {
 		idsMap, err = toIDsMap(*args.IDs)
 		if err != nil {

--- a/app/api/gql/schema.graphqls
+++ b/app/api/gql/schema.graphqls
@@ -238,6 +238,8 @@ type TeamUpdate {
 	"Given the user id, add the user to the team."
 	addMember(id: ID!): TeamUpdate!
 	removeMember(id: ID!): TeamUpdate!
+	"Remove the task from the team"
+	removeTask(id: ID!): TeamUpdate!
 	update(input: TeamUpdateInput!): TeamUpdate!
 	"Given the task id, promote an In Progress task to Need Attention."
 	promoteTaskToNeedAttention(Id: ID!): TeamUpdate!


### PR DESCRIPTION
Big Question: Place Oriented or Information Oriented?

We design team to be a container that contains a list of tasks. Therefore, removing/deleting a task can be interpreted in 2 ways:
1. Remove the task itself.
2. Remove the task from the team's list but itself remains.

With this PR, we have both APIs, one in `deleteTask` & another in `TeamUpdate`.

Because we currently design Task to able to exist outside of a team, we need both API.

The frontend uses No.1 and needs to change to No.2.

Consider in the future:
1. Do not allow a task to exist outside of a team. Personal/Private tasks are just tasks in a 1-person team. We can create a `Self` team for each user. This team does not need to exist in the database, it could be materialized by code.
2. Do not allow a task to exist in N>1 teams, if a team wants to observe the task of another team (which we are not solving yet), we should create a dedicated construct/type/logic to do it.

In that sense, a task will hold a reference to the team. Currently, it's `ownedByTeam` but this is used for "ownership" concept because currently N>1 teams can hold a reference to the same task.

我们一直没有画diagram，这次来看看我的设想
![image](https://user-images.githubusercontent.com/8919794/148036139-7ca80ac7-7ede-403c-94cd-e699a849fc4f.png)
https://whimsical.com/MXLBZRw5Ua5ZR8ciFLcoE8
（By the way，这个画图工具很好用，但是不能offline）
User和Team是Many to Many，Team和Task是One to Many。
只要不是迫不得已，最要不要Many-to-Many。多对多在产品上（用户的理解），技术上（数据查询等），UI上，都有一个量级以上的复杂度，相对于（1-to-Many）。

![image](https://user-images.githubusercontent.com/8919794/148036375-1778c74d-509a-4c26-b967-b21b294859da.png)
Sub-task和各种task之间的关系，如blocked by，值得三思。从拓扑topology上，sub-task和blocked-by没有任何区别。
当然，从一般的直观认知上，似乎sub-task就是一个从属或者封装的关系，好像parent task是个袋子，装了2个child tasks。但是这样就回到place oriented programming了，JIRA就是如此。他们把subtask和blocked-by做成的不同的东西。

但是，如果用graph theory的思维来理解，这些都是task之前的edge而已，所以，我建议在数据层面不要去区分。Task不是一个container。Child Task 和 Block By只是两种Task之前可能存在的关系而已。
![image](https://user-images.githubusercontent.com/8919794/148037054-734666bb-1052-4a57-8bbe-46b6336e1c50.png)
一旦我们脱离place oriented的思维，进入information flow的思维，就可以有非常powerful的应用了。

### Case 1：Priority Visualization
Topological Sort。这里我们可以Sort By `Blocked By`
我们就可以得出，Task 2需要最先做，然后是Task 3 或者Child Task 1，最后才是Child Task 2。

而且，我们也可以给不同的关系设置优先级，比如先sort by `Blocked By`，然后by `Parent Child`，最后甚至可以加上 due date之类的numeric sort。这是有实际用例的，比如topological sort的结果其实只能给task分批次，同一个批次的task因为没有依赖关系，所以就不知道先后，那么针对每个批次，可以使用numeric sort。

比如上面的图，做完了Task 2之后，先做Child Task 1然后Task 3也是可以的，因为他们之间无法用topology sort。这时候numeric sort一次就行了。

而这并不是限制用户一定要按照这个顺序来做，而是说，系统告诉了用户目前是这么一个优先级，用户自己把握。

### Case 2: Identify the bottom neck task （chain）
一旦通过topology sort后，就能够知道先解决那个task就能unblock最多的其他tasks。但是这里不能单纯地去数blocked by的数量，因为后面还可能有blocked by。

所以其实我们要解决的是，先解决哪个task blocking chain （一组tasks）的问题。而JIRA虽然记录的blocked by，但是却没有提供基于topological sort的这种information mining（sort of）。而这些都是small data就能解决的。

这个对于engineering manager是非常有用的。因为当东西大了，很难hold everything in their head。尤其是有cross team effort的时候。

### Case 3: Better Planning & Meeting
结合 1 & 2，我们就可以在开会的时候实时地知道，每个task的价值（how many it unblocks if done），以及加入新task所带来的成本（computed by how many tasks depends on it）。这样可以计算出每个sprint的价值，而不仅仅是task量。

甚至系统可以估算出可以并行开发的task chain的数量。比如只有一组 A->B->C，那这样就是不可并发开发的，因为有先后顺序。虽然也许3个程序员如果配合好，可以同时做然后integrate，但是这超出了系统的知识。

但是，如果是A, B->C,系统就知道至少有2并发开发可能性。

而这一切都不需要任何后端复杂的机器学习或者数据库查询，只需要前端实现不同的sort（transformation on Task list）。我们甚至不需要图数据库。