### PR TITLE
Implement automatic token refresh for GitHub App client

### DIFF
--- a/apps/github/client/app.go
+++ b/apps/github/client/app.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"github.com/golang-jwt/jwt"
+	"time"
+
+	"github.com/teamyapp/cloud/libs/errs"
+	"github.com/teamyapp/cloud/libs/telemetry"
+)
+
+type App struct {
+	dataCollector telemetry.DataCollector
+	appID         string
+	appPrivateKey *rsa.PrivateKey
+	jwt           *string
+	jwtExpireAt   *time.Time
+	installations map[string]*Installation
+}
+
+func (a *App) GetInstallation(installationID string) *Installation {
+	installation, ok := a.installations[installationID]
+	if ok {
+		return installation
+	}
+
+	installation = newInstallation(a.dataCollector, a, installationID)
+	a.installations[installationID] = installation
+	return installation
+}
+
+func (a *App) getOrRefreshAppJWT(ct context.Context) (string, *errs.Error) {
+	if a.jwt != nil && a.jwtExpireAt != nil {
+		// JWT token is not expired
+		if time.Now().UTC().Before(*a.jwtExpireAt) {
+			return *a.jwt, nil
+		}
+	}
+
+	// https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps
+	expireAt := time.Now().Add(10 * time.Minute)
+	payload := struct {
+		IssuedAt int64  `json:"iat"` // unix timestamp (UTC)
+		ExpireAt int64  `json:"exp"` // unix timestamp (UTC)
+		Issuer   string `json:"iss"` // GitHub App ID
+	}{
+		// To protect against clock drift between backend and GitHub, set this 1 minute in the past
+		IssuedAt: time.Now().Add(-1 * time.Minute).Unix(),
+		// no more than 10 minutes in the future based on CURRENT time (independent of IssuedAt)
+		ExpireAt: expireAt.Unix(),
+		Issuer:   a.appID,
+	}
+
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		internalErr := &errs.Error{
+			Code:     errs.Serialization,
+			EmbedErr: err,
+		}
+		a.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	payloadMap := make(map[string]interface{})
+	err = json.Unmarshal(buf, &payloadMap)
+	if err != nil {
+		internalErr := &errs.Error{
+			Code:     errs.Deserialization,
+			EmbedErr: err,
+		}
+		a.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(payloadMap))
+	signedStr, err := jwtToken.SignedString(a.appPrivateKey)
+	if err != nil {
+		internalErr := &errs.Error{
+			Code:     errs.Unknown,
+			EmbedErr: err,
+		}
+		a.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	a.jwt = &signedStr
+	a.jwtExpireAt = &expireAt
+	a.dataCollector.Logger.LogWithContext(ct, telemetry.Info, telemetry.Props{telemetry.MessageProp: fmt.Sprintf("Refreshed app JWT token expiring at %v", a.jwtExpireAt)})
+	return signedStr, nil
+}
+
+func NewApp(dataCollector telemetry.DataCollector, appID string, privateKeyPEM []byte) (*App, *errs.Error) {
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		internalErr := &errs.Error{
+			Code:     errs.InvalidArgument,
+			EmbedErr: err,
+		}
+		dataCollector.Logger.Log(telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return nil, internalErr
+	}
+
+	return &App{
+		appID:         appID,
+		appPrivateKey: privateKey,
+		installations: map[string]*Installation{},
+	}, nil
+}

--- a/apps/github/client/app.go
+++ b/apps/github/client/app.go
@@ -60,7 +60,7 @@ func (a *App) getOrRefreshAppJWT(ct context.Context) (string, *errs.Error) {
 			Code:     errs.Serialization,
 			EmbedErr: err,
 		}
-		a.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		a.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
@@ -71,7 +71,7 @@ func (a *App) getOrRefreshAppJWT(ct context.Context) (string, *errs.Error) {
 			Code:     errs.Deserialization,
 			EmbedErr: err,
 		}
-		a.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		a.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
@@ -82,13 +82,13 @@ func (a *App) getOrRefreshAppJWT(ct context.Context) (string, *errs.Error) {
 			Code:     errs.Unknown,
 			EmbedErr: err,
 		}
-		a.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		a.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
 	a.jwt = &signedStr
 	a.jwtExpireAt = &expireAt
-	a.dataCollector.Logger.LogWithContext(ct, telemetry.Info, telemetry.Props{telemetry.MessageProp: fmt.Sprintf("Refreshed app JWT token expiring at %v", a.jwtExpireAt)})
+	a.dataCollector.Logger.InfoWithContext(ct, fmt.Sprintf("Refreshed app JWT token expiring at %v", a.jwtExpireAt))
 	return signedStr, nil
 }
 
@@ -99,7 +99,7 @@ func NewApp(dataCollector telemetry.DataCollector, appID string, privateKeyPEM [
 			Code:     errs.InvalidArgument,
 			EmbedErr: err,
 		}
-		dataCollector.Logger.Log(telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		dataCollector.Logger.Error(internalErr)
 		return nil, internalErr
 	}
 

--- a/apps/github/client/app.go
+++ b/apps/github/client/app.go
@@ -5,9 +5,9 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"github.com/golang-jwt/jwt"
 	"time"
 
+	"github.com/golang-jwt/jwt"
 	"github.com/teamyapp/cloud/libs/errs"
 	"github.com/teamyapp/cloud/libs/telemetry"
 )

--- a/apps/github/client/installation.go
+++ b/apps/github/client/installation.go
@@ -34,7 +34,7 @@ func (i *Installation) GetOrRefreshAccessToken(ct context.Context) (string, *err
 
 	appJWT, internalErr := i.app.getOrRefreshAppJWT(ct)
 	if internalErr != nil {
-		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		i.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
@@ -45,7 +45,7 @@ func (i *Installation) GetOrRefreshAccessToken(ct context.Context) (string, *err
 			Code:     errs.Unknown,
 			EmbedErr: err,
 		}
-		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		i.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
@@ -61,7 +61,7 @@ func (i *Installation) GetOrRefreshAccessToken(ct context.Context) (string, *err
 			Code:     errs.Unknown,
 			EmbedErr: err,
 		}
-		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		i.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
@@ -90,7 +90,7 @@ func (i *Installation) GetOrRefreshAccessToken(ct context.Context) (string, *err
 			Code:     errs.IO,
 			EmbedErr: err,
 		}
-		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		i.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
@@ -117,13 +117,13 @@ func (i *Installation) GetOrRefreshAccessToken(ct context.Context) (string, *err
 			Code:     errs.Deserialization,
 			EmbedErr: err,
 		}
-		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		i.dataCollector.Logger.ErrorWithContext(ct, internalErr)
 		return "", internalErr
 	}
 
 	i.accessToken = &body.Token
 	i.expireAt = &body.ExpiresAt
-	i.dataCollector.Logger.LogWithContext(ct, telemetry.Info, telemetry.Props{telemetry.MessageProp: fmt.Sprintf("Refreshed access token expiring at %v", i.expireAt)})
+	i.dataCollector.Logger.InfoWithContext(ct, fmt.Sprintf("Refreshed access token expiring at %v", i.expireAt))
 	return body.Token, nil
 }
 

--- a/apps/github/client/installation.go
+++ b/apps/github/client/installation.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/teamyapp/cloud/libs/errs"
+	"github.com/teamyapp/cloud/libs/telemetry"
+)
+
+const (
+	gitHubAPIVersion = "2022-11-28"
+)
+
+type Installation struct {
+	dataCollector telemetry.DataCollector
+	app           *App
+	id            string
+	accessToken   *string
+	expireAt      *time.Time
+}
+
+func (i *Installation) GetOrRefreshAccessToken(ct context.Context) (string, *errs.Error) {
+	if i.accessToken != nil && i.expireAt != nil {
+		// access token is not expired
+		if time.Now().UTC().Before(*i.expireAt) {
+			return *i.accessToken, nil
+		}
+	}
+
+	appJWT, internalErr := i.app.getOrRefreshAppJWT(ct)
+	if internalErr != nil {
+		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	githubAppAccessTokenURL := fmt.Sprintf("https://api.github.com/app/installations/%s/access_tokens", i.id)
+	req, err := http.NewRequest("POST", githubAppAccessTokenURL, nil)
+	if err != nil {
+		internalErr = &errs.Error{
+			Code:     errs.Unknown,
+			EmbedErr: err,
+		}
+		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
+
+	bearerToken := fmt.Sprintf("Bearer %s", appJWT)
+	req.Header.Set("Authorization", bearerToken)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		internalErr = &errs.Error{
+			Code:     errs.Unknown,
+			EmbedErr: err,
+		}
+		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	switch res.StatusCode {
+	case http.StatusUnauthorized:
+		return "", &errs.Error{
+			Code: errs.Unauthenticated,
+		}
+	case http.StatusForbidden:
+		return "", &errs.Error{
+			Code: errs.PermissionDenied,
+		}
+	case http.StatusNotFound:
+		return "", &errs.Error{
+			Code: errs.NotFound,
+		}
+	case http.StatusUnprocessableEntity:
+		return "", &errs.Error{
+			Code: errs.Unknown,
+		}
+	}
+
+	buf, err := io.ReadAll(res.Body)
+	if err != nil {
+		internalErr = &errs.Error{
+			Code:     errs.IO,
+			EmbedErr: err,
+		}
+		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	// GitHub's authentication token format:
+	// ghp_ for Personal Access Tokens
+	// gho_ for OAuth Access tokens
+	// ghu_ for GitHub App user-to-server tokens
+	// ghs_ for GitHub App server-to-server tokens
+	// ghr_ for GitHub App refresh tokens
+	var body struct {
+		Token       string    `json:"token"` // ghs_
+		ExpiresAt   time.Time `json:"expires_at"`
+		Permissions struct {
+			Contents     string `json:"contents"`
+			Metadata     string `json:"metadata"`
+			PullRequests string `json:"pull_requests"`
+			Statuses     string `json:"statuses"`
+		} `json:"permissions"`
+		RepositorySelection string `json:"repository_selection"`
+	}
+	err = json.Unmarshal(buf, &body)
+	if err != nil {
+		internalErr = &errs.Error{
+			Code:     errs.Deserialization,
+			EmbedErr: err,
+		}
+		i.dataCollector.Logger.LogWithContext(ct, telemetry.Error, telemetry.Props{telemetry.CauseProp: internalErr})
+		return "", internalErr
+	}
+
+	i.accessToken = &body.Token
+	i.expireAt = &body.ExpiresAt
+	i.dataCollector.Logger.LogWithContext(ct, telemetry.Info, telemetry.Props{telemetry.MessageProp: fmt.Sprintf("Refreshed access token expiring at %v", i.expireAt)})
+	return body.Token, nil
+}
+
+func newInstallation(dataCollector telemetry.DataCollector, app *App, id string) *Installation {
+	return &Installation{
+		dataCollector: dataCollector,
+		app:           app,
+		id:            id,
+	}
+}


### PR DESCRIPTION
This implementation is for emergent use to unblock other feature development. It does **NOT** include thread-safe protections. Concurrency support will be added in the next pull request. 